### PR TITLE
Use launch files to launch AWS Cloud Extensions instead of running the nodes directly

### DIFF
--- a/robot_ws/src/cloudwatch_robot/launch/monitoring.launch
+++ b/robot_ws/src/cloudwatch_robot/launch/monitoring.launch
@@ -22,24 +22,23 @@
   <node pkg="cloudwatch_robot" type="monitor_distance_to_goal" name="monitor_distance_to_goal" output="log"/>
 
   <!-- Report health Metrics -->
-  <node pkg="health_metric_collector" type="health_metric_collector" name="health_metric_collector" respawn="true" output="log">
-      <!-- metrics sampling interval in seconds -->
-    <rosparam command="load" file="$(find cloudwatch_robot)/config/health_metrics_config.yaml" />
-  </node>
+  <include file="$(find health_metric_collector)/launch/health_metric_collector.launch" >
+    <arg name="config_file" value="$(find cloudwatch_robot)/config/health_metrics_config.yaml" />
+  </include>
 
   <!-- Enable CloudWatch Metrics reporting -->
   <arg name="aws_metrics_namespace" default="robomaker_cloudwatch_monitoring_example"/>
-  <node pkg="cloudwatch_metrics_collector" type="cloudwatch_metrics_collector" name="cloudwatch_metrics_collector">
-    <rosparam command="load" file="$(find cloudwatch_robot)/config/cloudwatch_metrics_config.yaml" />
-    <rosparam if="$(eval aws_region != '')" param="/cloudwatch_metrics_collector/aws_client_configuration/region" subst_value="true">$(arg aws_region)</rosparam>
-    <rosparam if="$(eval launch_id != '')" param="/cloudwatch_metrics_collector/aws_metrics_namespace" subst_value="true">$(arg aws_metrics_namespace)-$(arg launch_id)</rosparam>
-  </node>
+  <include file="$(find cloudwatch_metrics_collector)/launch/cloudwatch_metrics_collector.launch" >
+    <arg name="config_file" value="$(find cloudwatch_robot)/config/cloudwatch_metrics_config.yaml"/>
+  </include>
+  <rosparam if="$(eval aws_region != '')" param="/cloudwatch_metrics_collector/aws_client_configuration/region" subst_value="true">$(arg aws_region)</rosparam>
+  <rosparam if="$(eval launch_id != '')" param="/cloudwatch_metrics_collector/aws_metrics_namespace" subst_value="true">$(arg aws_metrics_namespace)-$(arg launch_id)</rosparam>
 
   <!-- Enable CloudWatch logging, send /rosout to CW Logs -->
   <arg name="log_group_name" default="robomaker_cloudwatch_monitoring_example" />
-  <node pkg="cloudwatch_logger" type="cloudwatch_logger" name="cloudwatch_logger">
-    <rosparam command="load" file="$(find cloudwatch_robot)/config/cloudwatch_logs_config.yaml" />
-    <rosparam if="$(eval aws_region != '')" param="/cloudwatch_logger/aws_client_configuration/region" subst_value="true">$(arg aws_region)</rosparam>
-    <rosparam if="$(eval launch_id != '')" param="/cloudwatch_logger/log_group_name" subst_value="true">$(arg log_group_name)-$(arg launch_id)</rosparam>
-  </node>
+  <include file="$(find cloudwatch_logger)/launch/cloudwatch_logger.launch">
+    <arg name="config_file" value="$(find cloudwatch_robot)/config/cloudwatch_logs_config.yaml" />
+  </include>
+  <rosparam if="$(eval aws_region != '')" param="/cloudwatch_logger/aws_client_configuration/region" subst_value="true">$(arg aws_region)</rosparam>
+  <rosparam if="$(eval launch_id != '')" param="/cloudwatch_logger/log_group_name" subst_value="true">$(arg log_group_name)-$(arg launch_id)</rosparam>
 </launch>

--- a/robot_ws/src/cloudwatch_robot/launch/monitoring.launch
+++ b/robot_ws/src/cloudwatch_robot/launch/monitoring.launch
@@ -11,7 +11,7 @@
 
   <!-- Optional launch ID, if specified, used for suffixing resource names -->
   <arg name="launch_id" value="$(optenv LAUNCH_ID)" doc="Used for resource name suffix if specified"/>
-
+  
   <!-- Report speed metrics to CloudWatch -->
   <node pkg="cloudwatch_robot" type="monitor_speed" name="monitor_speed" output="log"/>
 
@@ -27,18 +27,22 @@
   </include>
 
   <!-- Enable CloudWatch Metrics reporting -->
+  <arg name="metrics_node_name" value="cloudwatch_metrics_collector"/>
   <arg name="aws_metrics_namespace" default="robomaker_cloudwatch_monitoring_example"/>
   <include file="$(find cloudwatch_metrics_collector)/launch/cloudwatch_metrics_collector.launch" >
+    <arg name="node_name" value="$(arg metrics_node_name)"/>
     <arg name="config_file" value="$(find cloudwatch_robot)/config/cloudwatch_metrics_config.yaml"/>
   </include>
-  <rosparam if="$(eval aws_region != '')" param="/cloudwatch_metrics_collector/aws_client_configuration/region" subst_value="true">$(arg aws_region)</rosparam>
-  <rosparam if="$(eval launch_id != '')" param="/cloudwatch_metrics_collector/aws_metrics_namespace" subst_value="true">$(arg aws_metrics_namespace)-$(arg launch_id)</rosparam>
+  <rosparam if="$(eval aws_region != '')" param="/$(arg metrics_node_name)/aws_client_configuration/region" subst_value="true">$(arg aws_region)</rosparam>
+  <rosparam if="$(eval launch_id != '')" param="/$(arg metrics_node_name)/aws_metrics_namespace" subst_value="true">$(arg aws_metrics_namespace)-$(arg launch_id)</rosparam>
 
   <!-- Enable CloudWatch logging, send /rosout to CW Logs -->
+  <arg name="logger_node_name" value="cloudwatch_logger"/>
   <arg name="log_group_name" default="robomaker_cloudwatch_monitoring_example" />
   <include file="$(find cloudwatch_logger)/launch/cloudwatch_logger.launch">
+    <arg name="node_name" value="$(arg logger_node_name)"/>
     <arg name="config_file" value="$(find cloudwatch_robot)/config/cloudwatch_logs_config.yaml" />
   </include>
-  <rosparam if="$(eval aws_region != '')" param="/cloudwatch_logger/aws_client_configuration/region" subst_value="true">$(arg aws_region)</rosparam>
-  <rosparam if="$(eval launch_id != '')" param="/cloudwatch_logger/log_group_name" subst_value="true">$(arg log_group_name)-$(arg launch_id)</rosparam>
+  <rosparam if="$(eval aws_region != '')" param="/$(arg logger_node_name)/aws_client_configuration/region" subst_value="true">$(arg aws_region)</rosparam>
+  <rosparam if="$(eval launch_id != '')" param="/$(arg logger_node_name)/log_group_name" subst_value="true">$(arg log_group_name)-$(arg launch_id)</rosparam>
 </launch>


### PR DESCRIPTION
Changing the main launch file to include the launch files for cloudwatch logs, cloduwatch metrics, and health monitoring. This is the recommended way to include cloud extensions in your app. 

Tested to ensure all parameters are the same by running `monitoring.launch` on master and after these changes and performing a diff on the PARAMETERS list, ensuring it's exactly the same. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
