### PR TITLE
Use correct default value for storage resolution

### DIFF
--- a/robot_ws/src/cloudwatch_robot/config/cloudwatch_metrics_config.yaml
+++ b/robot_ws/src/cloudwatch_robot/config/cloudwatch_metrics_config.yaml
@@ -63,4 +63,4 @@ aws_client_configuration:
 # regular-resolution metric, which CloudWatch stores at 1-minute resolution.
 # Currently, high resolution is available only for custom metrics. For more
 # information about high-resolution metrics, see http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/publishingMetrics.html
-storage_resolution: 10
+storage_resolution: 1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Valid values for storage resolution in CW are 1 or 60, as seen in the [documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/publishingMetrics.html). This change fixes the default value to a valid value of 60, as in the [default configuration for cloudwatch_metrics_collector](https://github.com/aws-robotics/cloudwatchmetrics-ros1/blob/master/cloudwatch_metrics_collector/config/sample_configuration.yaml)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
