### PR TITLE
Fix #6: Depend on cloudwatchmetrics-ros1 v1.0.1

### DIFF
--- a/robot_ws/.rosinstall
+++ b/robot_ws/.rosinstall
@@ -6,6 +6,6 @@
 - git: {local-name: src/deps/utils-ros1, uri: 'https://github.com/aws-robotics/utils-ros1', version: v1.0.0}
 - git: {local-name: src/deps/cloudwatch-common, uri: 'https://github.com/aws-robotics/cloudwatch-common', version: v1.0.0}
 - git: {local-name: src/deps/cloudwatchlogs-ros1, uri: 'https://github.com/aws-robotics/cloudwatchlogs-ros1', version: v1.0.0}
-- git: {local-name: src/deps/cloudwatchmetrics-ros1, uri: 'https://github.com/aws-robotics/cloudwatchmetrics-ros1', version: v1.0.0}
+- git: {local-name: src/deps/cloudwatchmetrics-ros1, uri: 'https://github.com/aws-robotics/cloudwatchmetrics-ros1', version: v1.0.1}
 - git: {local-name: src/deps/health-metrics-collector-ros1, uri: 'https://github.com/aws-robotics/health-metrics-collector-ros1', version: v1.0.0}
 - git: {local-name: src/deps/monitoringmessages-ros1, uri: 'https://github.com/aws-robotics/monitoringmessages-ros1', version: v1.0.0}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Depend on branch v1.0.1 of cloudwatchmetrics-ros1 that extends v1.0.0 with the fix of the time stamp bug, see https://github.com/aws-robotics/cloudwatchmetrics-ros1/commits/v1.0.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
