### PR TITLE
Add a launch file for Turtlebot physcial robot to await commands with…

### DIFF
--- a/robot_ws/src/cloudwatch_robot/deploymentScripts/post_check_monitor_nodes.sh
+++ b/robot_ws/src/cloudwatch_robot/deploymentScripts/post_check_monitor_nodes.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# This is a script which can be run after launching the ROS processes.
+# You can include a post-check of ROS processes in this post-launch file. 
+# Non-zero exit status from script would cause robot deployment failure. 
+# Use "deploymentScripts/post_launch_file.sh" as the postLaunchFile path.
+
+# Wait all monitoring nodes starts.
+sleep 30
+# ping and verify nodes started
+rosnode ping -c 3 monitor_speed
+rosnode ping -c 3 monitor_obstacle_distance
+rosnode ping -c 3 monitor_distance_to_goal
+rosnode ping -c 3 cloudwatch_logger
+rosnode ping -c 3 cloudwatch_metrics_collector
+rosnode ping -c 3 health_metric_collector

--- a/robot_ws/src/cloudwatch_robot/launch/deploy_await_commands.launch
+++ b/robot_ws/src/cloudwatch_robot/launch/deploy_await_commands.launch
@@ -1,0 +1,19 @@
+<launch>
+  <!--
+        Launch command for a physical Turtlebot to await commands with monitoring enabled.
+
+        Use this with bookstore_turtlebot_navigation for routing though 
+        the bookstore. Or use with remote steering via RQT or RViz 
+        launchers or on the terminal with turtlebot3_teleop. 
+  -->
+
+  <!-- Bringup turtlebot3 -->
+  <include file="$(find turtlebot3_bringup)/launch/turtlebot3_robot.launch"/>
+
+  <!-- Deploy await commands with monitoring enabled -->
+  <include file="$(find cloudwatch_robot)/launch/await_commands.launch">
+    <arg name="use_sim_time" value="false" />
+  </include>
+
+  <!-- Do nothing, await Goal Commands from simulation -->
+</launch>


### PR DESCRIPTION
This change add a launch file to launch a physical robot with await_commands.launch. Since the RoboMaker Deploy API does not accept a command-line argument, so we can't have a launch argument to turn on/off turtlebot3_bringup right now. We have created a SIM to add this feature later in our backlog.

And change also add a post script to verify the ROS nodes started, which will be use in deployment job as a [postLaunchFile](https://docs.aws.amazon.com/robomaker/latest/dg/API_DeploymentLaunchConfig.html)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.