### PR TITLE
Remove setup-file element from .rosinstall

### DIFF
--- a/robot_ws/.rosinstall
+++ b/robot_ws/.rosinstall
@@ -1,6 +1,3 @@
-# kinetic.rosinstall
-- setup-file: {local-name: /opt/ros/kinetic/setup.sh}
-
 # Amazon ROS CloudServiceIntegration package dependencies
 - git: {local-name: src/deps/utils-common, uri: 'https://github.com/aws-robotics/utils-common', version: v1.0.0}
 - git: {local-name: src/deps/utils-ros1, uri: 'https://github.com/aws-robotics/utils-ros1', version: v1.0.0}

--- a/simulation_ws/.rosinstall
+++ b/simulation_ws/.rosinstall
@@ -1,5 +1,2 @@
-# kinetic.rosinstall
-- setup-file: {local-name: /opt/ros/kinetic/setup.sh}
-
 - git: {local-name: src/aws-robomaker-bookstore-world, uri: "https://github.com/aws-robotics/aws-robomaker-bookstore-world.git", version: v0.0.1}
 - git: {local-name: src/turtlebot3_simulations, uri: "https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git", version: 1.2.0}

--- a/simulation_ws/.rosinstall
+++ b/simulation_ws/.rosinstall
@@ -1,2 +1,2 @@
-- git: {local-name: src/aws-robomaker-bookstore-world, uri: "https://github.com/aws-robotics/aws-robomaker-bookstore-world.git", version: v0.0.1}
-- git: {local-name: src/turtlebot3_simulations, uri: "https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git", version: 1.2.0}
+- git: {local-name: src/deps/aws-robomaker-bookstore-world, uri: "https://github.com/aws-robotics/aws-robomaker-bookstore-world.git", version: v0.0.1}
+- git: {local-name: src/deps/turtlebot3_simulations, uri: "https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git", version: 1.2.0}


### PR DESCRIPTION
Not needed and will just confuse customers as we also support Melodic.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
