### PR TITLE
Use release-latest version of all Cloud Extensions

### DIFF
--- a/robot_ws/.rosinstall
+++ b/robot_ws/.rosinstall
@@ -1,8 +1,8 @@
 # Amazon ROS CloudServiceIntegration package dependencies
-- git: {local-name: src/deps/utils-common, uri: 'https://github.com/aws-robotics/utils-common', version: v1.0.0}
-- git: {local-name: src/deps/utils-ros1, uri: 'https://github.com/aws-robotics/utils-ros1', version: v1.0.0}
-- git: {local-name: src/deps/cloudwatch-common, uri: 'https://github.com/aws-robotics/cloudwatch-common', version: v1.0.0}
-- git: {local-name: src/deps/cloudwatchlogs-ros1, uri: 'https://github.com/aws-robotics/cloudwatchlogs-ros1', version: v1.0.0}
-- git: {local-name: src/deps/cloudwatchmetrics-ros1, uri: 'https://github.com/aws-robotics/cloudwatchmetrics-ros1', version: v1.0.1}
-- git: {local-name: src/deps/health-metrics-collector-ros1, uri: 'https://github.com/aws-robotics/health-metrics-collector-ros1', version: v1.0.0}
-- git: {local-name: src/deps/monitoringmessages-ros1, uri: 'https://github.com/aws-robotics/monitoringmessages-ros1', version: v1.0.0}
+- git: {local-name: src/deps/utils-common, uri: 'https://github.com/aws-robotics/utils-common', version: 'release-latest'}
+- git: {local-name: src/deps/utils-ros1, uri: 'https://github.com/aws-robotics/utils-ros1', version: 'release-latest'}
+- git: {local-name: src/deps/cloudwatch-common, uri: 'https://github.com/aws-robotics/cloudwatch-common', version: 'release-latest'}
+- git: {local-name: src/deps/cloudwatchlogs-ros1, uri: 'https://github.com/aws-robotics/cloudwatchlogs-ros1', version: 'release-latest'}
+- git: {local-name: src/deps/cloudwatchmetrics-ros1, uri: 'https://github.com/aws-robotics/cloudwatchmetrics-ros1', version: 'release-latest'}
+- git: {local-name: src/deps/health-metrics-collector-ros1, uri: 'https://github.com/aws-robotics/health-metrics-collector-ros1', version: 'release-latest'}
+- git: {local-name: src/deps/monitoringmessages-ros1, uri: 'https://github.com/aws-robotics/monitoringmessages-ros1', version: 'release-latest'}


### PR DESCRIPTION
Now that CloudWatch Offline is released we should use it and always use the latest version of all our Cloud Extensions for our sample application.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
