### PR TITLE
Use gazebo_ros launch scripts and fix route_manager

### DIFF
--- a/simulation_ws/.rosinstall
+++ b/simulation_ws/.rosinstall
@@ -1,7 +1,4 @@
 - git: {local-name: src/deps/aws-robomaker-bookstore-world, uri: "https://github.com/aws-robotics/aws-robomaker-bookstore-world", version: ros2-devel}
 - git: {local-name: src/deps/xacro, uri: "https://github.com/AAlon/xacro", version: ros2-find} 
-- git: {local-name: src/deps/turtlebot3, uri: "https://github.com/ROBOTIS-GIT/turtlebot3", version: ros2}
-- git: {local-name: src/deps/turtlebot3_simulations, uri: "https://github.com/ROBOTIS-GIT/turtlebot3_simulations", version: ros2}
-- git: {local-name: src/deps/cartographer/cartographer_ros, uri: 'https://github.com/ROBOTIS-GIT/cartographer_ros.git', version: dashing}
 - git: {local-name: src/deps/navigation_msgs, uri: 'https://github.com/ros-planning/navigation_msgs.git', version: ros2}
 

--- a/simulation_ws/src/aws_robomaker_simulation_common/package.xml
+++ b/simulation_ws/src/aws_robomaker_simulation_common/package.xml
@@ -8,7 +8,6 @@
   <author email="ros-contributions@amazon.com">AWS RoboMaker</author>
   <maintainer email="ros-contributions@amazon.com">AWS RoboMaker</maintainer>
   <license>Apache 2.0</license>
-  <buildtool_depend>ament_cmake</buildtool_depend>
   <depend>rclpy</depend>
   <depend>move_base_msgs</depend>
   <depend>python-yaml</depend>

--- a/simulation_ws/src/cloudwatch_simulation/launch/bookstore_turtlebot_navigation.launch.py
+++ b/simulation_ws/src/cloudwatch_simulation/launch/bookstore_turtlebot_navigation.launch.py
@@ -34,7 +34,8 @@ def generate_launch_description():
             node_name='route_manager',
             output='screen',
             parameters=[{
-                'route_file': os.path.join(get_package_share_directory('aws_robomaker_bookstore_world'), 'routes', 'route.yaml')
+                # Route file is passed as "<package_name>.<relative path in install space>" due to limitations on string parameter size.
+                'route_file': '.'.join(['aws_robomaker_bookstore_world', os.path.join('routes', 'route.yaml')])
             }],
             condition=launch.conditions.IfCondition(
                 launch.substitutions.LaunchConfiguration('follow_route'))

--- a/simulation_ws/src/cloudwatch_simulation/launch/turtlebot3_navigation.launch.py
+++ b/simulation_ws/src/cloudwatch_simulation/launch/turtlebot3_navigation.launch.py
@@ -63,7 +63,7 @@ def generate_launch_description():
         launch.actions.IncludeLaunchDescription(
             launch.launch_description_sources.PythonLaunchDescriptionSource(
                 os.path.join(get_package_share_directory(
-                    'turtlebot3_navigation2'), 'launch', 'move_base.launch.py')
+                    'turtlebot3_navigation'), 'launch', 'move_base.launch.py')
             ),
             launch_arguments={
                 'model': launch.substitutions.LaunchConfiguration('model')

--- a/simulation_ws/src/cloudwatch_simulation/launch/turtlebot3_navigation.launch.py
+++ b/simulation_ws/src/cloudwatch_simulation/launch/turtlebot3_navigation.launch.py
@@ -63,7 +63,7 @@ def generate_launch_description():
         launch.actions.IncludeLaunchDescription(
             launch.launch_description_sources.PythonLaunchDescriptionSource(
                 os.path.join(get_package_share_directory(
-                    'turtlebot3_navigation'), 'launch', 'move_base.launch.py')
+                    'turtlebot3_navigation2'), 'launch', 'move_base.launch.py')
             ),
             launch_arguments={
                 'model': launch.substitutions.LaunchConfiguration('model')

--- a/simulation_ws/src/cloudwatch_simulation/package.xml
+++ b/simulation_ws/src/cloudwatch_simulation/package.xml
@@ -20,5 +20,6 @@
   <depend>turtlebot3</depend>
   <export>
     <build_type>ament_python</build_type>
+    <gazebo_ros gazebo_media_path="${prefix}/worlds"/>
   </export>
 </package>

--- a/simulation_ws/src/turtlebot3_description_reduced_mesh/launch/spawn_turtlebot.launch.py
+++ b/simulation_ws/src/turtlebot3_description_reduced_mesh/launch/spawn_turtlebot.launch.py
@@ -32,12 +32,6 @@ import subprocess
 
 def generate_launch_description():
     turtlebot3_model = "turtlebot3_" + os.environ.get('TURTLEBOT3_MODEL', 'waffle_pi') + ".urdf"
-    env = {
-        'GAZEBO_MODEL_PATH': ":".join([
-            os.environ.get('GAZEBO_MODEL_PATH', ''),
-            os.path.split(get_package_share_directory('turtlebot3_description_reduced_mesh'))[0]
-        ]) 
-    } 
 
     ld = launch.LaunchDescription([
         launch.actions.DeclareLaunchArgument(
@@ -71,7 +65,6 @@ def generate_launch_description():
         launch_ros.actions.Node(
             package='gazebo_ros',
             node_executable='spawn_entity.py',
-            additional_env=env,
             output='screen',
             arguments=[
                 '-entity',

--- a/simulation_ws/src/turtlebot3_description_reduced_mesh/package.xml
+++ b/simulation_ws/src/turtlebot3_description_reduced_mesh/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>turtlebot3_description_reduced_mesh</name>
-  <version>1.1.0</version>
+  <version>2.0.0</version>
   <description>
     A copy of the TurtleBot3 models with reduced poly counts. Based off turtlebot3_description package.
   </description>
@@ -14,5 +14,6 @@
   <exec_depend>gazebo</exec_depend>
   <export>
     <build_type>ament_cmake</build_type>
+    <gazebo_ros gazebo_model_path="${prefix}/.."/>
   </export>
 </package>


### PR DESCRIPTION
Similar to https://github.com/aws-robotics/aws-robomaker-sample-application-helloworld/pull/33
Contains the following fixes:
* Gazebo paths fix to avoid having to override the environment variable (enables RoboMaker support). Also needs https://github.com/aws-robotics/aws-robomaker-bookstore-world/pull/6
* Remove released dependencies from .rosinstall
* route_manager fixes:
  * Should be invoked with python3
  * Syntax errors
  * Parameter loading of route_file

Btw @timrobotson it seems that `move_base` is not really a thing in ROS2 so we'll need additional fixes (see https://github.com/ros-planning/navigation2/blob/dashing-devel/doc/design/ROS_COMPARISON.md).

-----

Verified the world & TB were loaded correctly when invoked by:

`ros2 launch cloudwatch_simulation empty_world.launch.py gui:=true`

`ros2 launch cloudwatch_simulation bookstore_turtlebot_navigation.launch.py gui:=true`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
