### PR TITLE
Add ROS2 navigation

### DIFF
--- a/simulation_ws/src/cloudwatch_simulation/launch/bookstore_turtlebot3_navigation.launch.py
+++ b/simulation_ws/src/cloudwatch_simulation/launch/bookstore_turtlebot3_navigation.launch.py
@@ -68,19 +68,19 @@ def generate_launch_description():
                 'use_sim_time': launch.substitutions.LaunchConfiguration('use_sim_time'),
             }.items()
         ),
-        # launch.actions.IncludeLaunchDescription(
-        #     launch.launch_description_sources.PythonLaunchDescriptionSource(
-        #         os.path.join(get_package_share_directory(
-        #             'cloudwatch_simulation'), 'launch', 'turtlebot3_navigation.launch.py')
-        #     ),
-        #     launch_arguments={
-        #         'map_file': os.path.join(get_package_share_directory('aws_robomaker_bookstore_world'), 'maps', f"turtlebot3_{os.environ.get('TURTLEBOT3_MODEL', 'waffle_pi')}", 'map.yaml'),
-        #         'initial_pose_x': launch.substitutions.LaunchConfiguration('x_pos'),
-        #         'initial_pose_y': launch.substitutions.LaunchConfiguration('y_pos'),
-        #         'initial_pose_a': launch.substitutions.LaunchConfiguration('yaw'),
-        #         'open_rviz': 'false'
-        #     }.items()
-        # )
+        launch.actions.IncludeLaunchDescription(
+            launch.launch_description_sources.PythonLaunchDescriptionSource(
+                os.path.join(get_package_share_directory(
+                    'cloudwatch_simulation'), 'launch', 'turtlebot3_navigation.launch.py')
+            ),
+            launch_arguments={
+                'map_file': os.path.join(get_package_share_directory('aws_robomaker_bookstore_world'), 'maps', f"turtlebot3_{os.environ.get('TURTLEBOT3_MODEL', 'waffle_pi')}", 'map.yaml'),
+                'initial_pose_x': launch.substitutions.LaunchConfiguration('x_pos'),
+                'initial_pose_y': launch.substitutions.LaunchConfiguration('y_pos'),
+                'initial_pose_a': launch.substitutions.LaunchConfiguration('yaw'),
+                'open_rviz': 'false'
+            }.items()
+        )
     ])
     return ld
 

--- a/simulation_ws/src/cloudwatch_simulation/launch/turtlebot3_navigation.launch.py
+++ b/simulation_ws/src/cloudwatch_simulation/launch/turtlebot3_navigation.launch.py
@@ -7,6 +7,9 @@ from ament_index_python.packages import get_package_share_directory
 
 
 def generate_launch_description():
+    TURTLEBOT3_MODEL = os.environ['TURTLEBOT3_MODEL']
+    param_file_name = TURTLEBOT3_MODEL + '.yaml'
+    param_file_path = os.path.join(get_package_share_directory('turtlebot3_navigation2'), 'param', param_file_name)
     ld = launch.LaunchDescription([
         launch.actions.DeclareLaunchArgument(
             name='model',
@@ -18,6 +21,10 @@ def generate_launch_description():
             name='map_file',
             default_value=os.path.join(get_package_share_directory(
                 'turtlebot3_navigation2') + 'map', 'map.yaml')
+        ),
+        launch.actions.DeclareLaunchArgument(
+            name='use_sim_time',
+            default_value='false'
         ),
         launch.actions.DeclareLaunchArgument(
             name='open_rviz',
@@ -35,38 +42,45 @@ def generate_launch_description():
             name='initial_pose_a',
             default_value='0.0'
         ),
-        launch_ros.actions.Node(
-            package='map_server',
-            node_executable='map_server',
-            node_name='map_server',
-            arguments=[launch.substitutions.LaunchConfiguration('map_file')]
-        ),
-        launch_ros.actions.Node(
-            package='rviz',
-            node_executable='rviz',
-            node_name='rviz',
-            on_exit=launch.actions.Shutdown(),
-            condition=launch.conditions.IfCondition(
-                launch.substitutions.LaunchConfiguration('open_rviz'))
-        ),
+        # launch_ros.actions.Node(
+        #     package='map_server',
+        #     node_executable='map_server',
+        #     node_name='map_server',
+        #     arguments=[launch.substitutions.LaunchConfiguration('map_file')]
+        # ),
+        # launch_ros.actions.Node(
+        #     package='rviz',
+        #     node_executable='rviz',
+        #     node_name='rviz',
+        #     on_exit=launch.actions.Shutdown(),
+        #     condition=launch.conditions.IfCondition(
+        #         launch.substitutions.LaunchConfiguration('open_rviz'))
+        # ),
+        # launch.actions.IncludeLaunchDescription(
+        #     launch.launch_description_sources.PythonLaunchDescriptionSource(
+        #         os.path.join(get_package_share_directory(
+        #             'turtlebot3_navigation2'), 'launch', 'amcl.launch.py')
+        #     ),
+        #     launch_arguments={
+        #         'initial_pose_x': launch.substitutions.LaunchConfiguration('initial_pose_x'),
+        #         'initial_pose_y': launch.substitutions.LaunchConfiguration('initial_pose_y'),
+        #         'initial_pose_a': launch.substitutions.LaunchConfiguration('initial_pose_a')
+        #     }.items()
+        # ),
+        # launch_ros.actions.Node(
+        #     package='nav2_bt_navigator',
+        #     node_executable='bt_navigator',
+        #     node_name='bt_navigator',
+        # )
         launch.actions.IncludeLaunchDescription(
             launch.launch_description_sources.PythonLaunchDescriptionSource(
                 os.path.join(get_package_share_directory(
-                    'turtlebot3_navigation2'), 'launch', 'amcl.launch.py')
+                    'nav2_bringup'), 'launch', 'nav2_bringup_launch.py')
             ),
             launch_arguments={
-                'initial_pose_x': launch.substitutions.LaunchConfiguration('initial_pose_x'),
-                'initial_pose_y': launch.substitutions.LaunchConfiguration('initial_pose_y'),
-                'initial_pose_a': launch.substitutions.LaunchConfiguration('initial_pose_a')
-            }.items()
-        ),
-        launch.actions.IncludeLaunchDescription(
-            launch.launch_description_sources.PythonLaunchDescriptionSource(
-                os.path.join(get_package_share_directory(
-                    'turtlebot3_navigation'), 'launch', 'move_base.launch.py')
-            ),
-            launch_arguments={
-                'model': launch.substitutions.LaunchConfiguration('model')
+                'map': launch.substitutions.LaunchConfiguration('map_file'),
+                'use_sim_time': launch.substitutions.LaunchConfiguration('use_sim_time'),
+                'params': param_file_path
             }.items()
         )
     ])

--- a/simulation_ws/src/cloudwatch_simulation/package.xml
+++ b/simulation_ws/src/cloudwatch_simulation/package.xml
@@ -18,6 +18,7 @@
   <depend>gazebo_ros</depend>
   <depend>gazebo_plugins</depend>
   <depend>turtlebot3</depend>
+  <depend>nav2_bringup</depend>
   <export>
     <build_type>ament_python</build_type>
   </export>


### PR DESCRIPTION
*Note: Not working yet, do not merge*

Previously to make navigation work we loaded the package turtlebot_navigation from https://github.com/ROBOTIS-GIT/turtlebot3/tree/master/turtlebot3_navigation. Which loaded move_base.launch which made it so the turtlebot can be moved by publishing coordinates to the action server. 

This has been turned into turtlebot3_navigation2 which only has one launch file, loads nav2_bringup, and automatically shows rviz on launch (which we don't want, we may want to submit a PR to them to add an `open_rviz` launch argument). 

To try and get navigation working I've included the `ros-planning/navigation2` package and am calling the bringup launch file https://github.com/ros-planning/navigation2/blob/master/nav2_bringup/launch/nav2_bringup_launch.py which then launches `nav2_bt_navigator` which is the ROS2 equivilant of move_base. 

Unfortunately this isn't working yet. We can try any of the following to get navigation working:

- Include turtlebot3_navigation2 in our launch file
- Include nav2_bringup
- Include nav2_bt_navigator by itself

The message type and topic of the ActionClient in route_manager.py probably also needs to be changed. 

There is also an issue with the path to bookstore_world map file being over 128 bytes long, unsure how we're going to address this. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
