### PR TITLE
Remove released turtlebot dependencies from simulation_ws/.rosinstall

### DIFF
--- a/simulation_ws/.rosinstall
+++ b/simulation_ws/.rosinstall
@@ -1,3 +1,1 @@
 - git: {local-name: src/deps/aws-robomaker-bookstore-world, uri: "https://github.com/aws-robotics/aws-robomaker-bookstore-world", version: v0.0.1}
-- git: {local-name: src/deps/turtlebot3, uri: "https://github.com/ROBOTIS-GIT/turtlebot3", version: d3cdcc6647812ae9a83f05e626cdae322923ac84}
-- git: {local-name: src/deps/turtlebot3_simulations, uri: "https://github.com/ROBOTIS-GIT/turtlebot3_simulations", version: 1.2.0}


### PR DESCRIPTION
To address https://github.com/aws-robotics/aws-robomaker-sample-application-cloudwatch/issues/26

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
