### PR TITLE
Update post_check_monitor_nodes.sh for ROS2

### DIFF
--- a/robot_ws/src/cloudwatch_robot/deploymentScripts/post_check_monitor_nodes.sh
+++ b/robot_ws/src/cloudwatch_robot/deploymentScripts/post_check_monitor_nodes.sh
@@ -7,9 +7,10 @@
 # Wait all monitoring nodes starts.
 sleep 30
 # ping and verify nodes started
-rosnode ping -c 3 monitor_speed
-rosnode ping -c 3 monitor_obstacle_distance
-rosnode ping -c 3 monitor_distance_to_goal
-rosnode ping -c 3 cloudwatch_logger
-rosnode ping -c 3 cloudwatch_metrics_collector
-rosnode ping -c 3 health_metric_collector
+set -e
+ros2 node info /monitor_speed
+ros2 node info /monitor_obstacle_distance
+ros2 node info /monitor_distance_to_goal
+ros2 node info /cloudwatch_logger
+ros2 node info /cloudwatch_metrics_collector
+ros2 node info /health_metric_collector


### PR DESCRIPTION
`ping` doesn't exist in ROS2.
Tested locally (script exits with 1 when one of the nodes doesn't exist and with 0 when all nodes exist).

Also opened https://github.com/aws-robotics/aws-robomaker-sample-application-cloudwatch/pull/52 to add `set -e` to the ROS1 version.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
