### PR TITLE
Failed `rosnode ping` should cause post_check_monitor_nodes.sh to exit

### DIFF
--- a/robot_ws/src/cloudwatch_robot/deploymentScripts/post_check_monitor_nodes.sh
+++ b/robot_ws/src/cloudwatch_robot/deploymentScripts/post_check_monitor_nodes.sh
@@ -7,6 +7,7 @@
 # Wait all monitoring nodes starts.
 sleep 30
 # ping and verify nodes started
+set -e
 rosnode ping -c 3 monitor_speed
 rosnode ping -c 3 monitor_obstacle_distance
 rosnode ping -c 3 monitor_distance_to_goal


### PR DESCRIPTION
Right now as long as the last node (`health_metric_collector`) is up, it doesn't matter what was the result of earlier `rosnode ping`s.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
