### PR TITLE
Use official port of xacro

### DIFF
--- a/simulation_ws/.rosinstall
+++ b/simulation_ws/.rosinstall
@@ -1,2 +1,2 @@
 - git: {local-name: src/deps/aws-robomaker-bookstore-world, uri: "https://github.com/aws-robotics/aws-robomaker-bookstore-world", version: ros2}
-- git: {local-name: src/deps/xacro, uri: "https://github.com/AAlon/xacro", version: ros2-find} 
+- git: {local-name: src/deps/xacro, uri: "https://github.com/ros/xacro", version: 2.0.1} 


### PR DESCRIPTION
Will be able to remove this altogether once 2.0.1 is in apt: http://repo.ros2.org/status_page/ros_dashing_default.html?q=xacro

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
