### PR TITLE
Log metrics to screen by default

### DIFF
--- a/robot_ws/.rosinstall
+++ b/robot_ws/.rosinstall
@@ -3,6 +3,6 @@
 - git: {local-name: src/deps/utils-ros1, uri: 'https://github.com/aws-robotics/utils-ros1', version: 'release-latest'}
 - git: {local-name: src/deps/cloudwatch-common, uri: 'https://github.com/aws-robotics/cloudwatch-common', version: 'release-latest'}
 - git: {local-name: src/deps/cloudwatchlogs-ros1, uri: 'https://github.com/aws-robotics/cloudwatchlogs-ros1', version: 'release-latest'}
-- git: {local-name: src/deps/cloudwatchmetrics-ros1, uri: 'https://github.com/aws-robotics/cloudwatchmetrics-ros1', version: 'release-latest'}
+- git: {local-name: src/deps/cloudwatchmetrics-ros1, uri: 'https://github.com/aws-robotics/cloudwatchmetrics-ros1', version: 'master'}
 - git: {local-name: src/deps/health-metrics-collector-ros1, uri: 'https://github.com/aws-robotics/health-metrics-collector-ros1', version: 'release-latest'}
 - git: {local-name: src/deps/monitoringmessages-ros1, uri: 'https://github.com/aws-robotics/monitoringmessages-ros1', version: 'release-latest'}

--- a/robot_ws/src/cloudwatch_robot/launch/monitoring.launch
+++ b/robot_ws/src/cloudwatch_robot/launch/monitoring.launch
@@ -30,6 +30,7 @@
   <arg name="metrics_node_name" value="cloudwatch_metrics_collector"/>
   <arg name="aws_metrics_namespace" default="robomaker_cloudwatch_monitoring_example"/>
   <include file="$(find cloudwatch_metrics_collector)/launch/cloudwatch_metrics_collector.launch" >
+    <arg name="output" value="screen"/>
     <arg name="node_name" value="$(arg metrics_node_name)"/>
     <arg name="config_file" value="$(find cloudwatch_robot)/config/cloudwatch_metrics_config.yaml"/>
   </include>
@@ -40,6 +41,7 @@
   <arg name="logger_node_name" value="cloudwatch_logger"/>
   <arg name="log_group_name" default="robomaker_cloudwatch_monitoring_example" />
   <include file="$(find cloudwatch_logger)/launch/cloudwatch_logger.launch">
+    <arg name="output" value="screen"/>
     <arg name="node_name" value="$(arg logger_node_name)"/>
     <arg name="config_file" value="$(find cloudwatch_robot)/config/cloudwatch_logs_config.yaml" />
   </include>


### PR DESCRIPTION
- Log all metric output to the screen, it goes to log by default
currently. So that we can diagnose integration test failures easier.
- Use latest master of cloudwatchmetrics for now as release-latest has a
bug in it causing offline metrics to be saved to cwlogs folder instead (https://github.com/aws-robotics/cloudwatchmetrics-ros1/compare/release-latest...master, bug is fixed with https://github.com/aws-robotics/cloudwatchmetrics-ros1/pull/38). We need to do a new bloom release of cloudwatch metrics. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
