### PR TITLE
Fix Obstacle Distance Laser Scanner Node

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,10 +154,6 @@ You'll need to upload these to an s3 bucket, then you can use these files to
 [create a simulation application](https://docs.aws.amazon.com/robomaker/latest/dg/create-simulation-application.html), 
 and [create a simulation job](https://docs.aws.amazon.com/robomaker/latest/dg/create-simulation-job.html) in RoboMaker.
 
-## Known Issues
-
-There is currently an issue with the LaserScan messages emitted from the [gazebo lidar plugin](https://github.com/ros-simulation/gazebo_ros_pkgs/wiki/ROS-2-Migration:-Ray-sensors) not being received by the `monitor_obstacle_distance` node. We're still investigating why this is occuring. 
-
 ## AWS ROS Packages used by this Sample
 
 - [utils-common](https://github.com/aws-robotics/utils-common)

--- a/robot_ws/src/cloudwatch_robot/src/cloudwatch_robot/monitor_obstacle_distance.py
+++ b/robot_ws/src/cloudwatch_robot/src/cloudwatch_robot/monitor_obstacle_distance.py
@@ -20,6 +20,7 @@ import time
 
 import rclpy
 from rclpy.node import Node
+from rclpy.qos import QoSPresetProfiles
 from std_msgs.msg import Header
 from sensor_msgs.msg import LaserScan
 from ros_monitoring_msgs.msg import MetricList, MetricData, MetricDimension
@@ -27,7 +28,8 @@ from ros_monitoring_msgs.msg import MetricList, MetricData, MetricDimension
 class MonitorObstacleDistance(Node):
     def __init__(self):
         super().__init__('monitor_obstacle_distance')
-        self.scan_sub = self.create_subscription(LaserScan, "/scan", self.report_metric, 5)
+        qos_profile = QoSPresetProfiles.SENSOR_DATA.value
+        self.scan_sub = self.create_subscription(LaserScan, "/scan", self.report_metric, qos_profile)
         self.metrics_pub = self.create_publisher(MetricList, "/metrics", 1)
 
     def filter_scan(self, msg):


### PR DESCRIPTION
- When manually constructing a QoS profile with only the depth value, or
only passing a depth value to the QoS parameter when creating a
subscription, the subscription will not pick up LaserScan messages.
Using the SENSOR_DATA QoS profile works.

Fixes #57 

## Testing

- Tested running locally with simulation_ws and it previously did not pick up scan messages unless they were re-echo'd on the CLI (see ROS-2968 in SIM). After this change the scan messages are picked up correctly. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
