### PR TITLE
Remove turtlebot3 packages from .rosinstall

### DIFF
--- a/simulation_ws/.rosinstall
+++ b/simulation_ws/.rosinstall
@@ -1,5 +1,3 @@
 - git: {local-name: src/deps/aws-robomaker-bookstore-world, uri: "https://github.com/aws-robotics/aws-robomaker-bookstore-world", version: v0.0.1}
 - git: {local-name: src/deps/aws-robomaker-small-house-world, uri: "https://github.com/aws-robotics/aws-robomaker-small-house-world", version: ros1}
-- git: {local-name: src/deps/turtlebot3, uri: "https://github.com/ROBOTIS-GIT/turtlebot3", version: d3cdcc6647812ae9a83f05e626cdae322923ac84}
-- git: {local-name: src/deps/turtlebot3_simulations, uri: "https://github.com/ROBOTIS-GIT/turtlebot3_simulations", version: 1.2.0}
 - git: {local-name: src/deps/aws-robomaker-simulation-ros-pkgs, uri: 'https://github.com/aws-robotics/aws-robomaker-simulation-ros-pkgs.git', version: master}

--- a/simulation_ws/src/cloudwatch_simulation/package.xml
+++ b/simulation_ws/src/cloudwatch_simulation/package.xml
@@ -18,7 +18,6 @@
   <depend>gazebo_ros</depend>
   <depend>gazebo_plugins</depend>
   <depend>turtlebot3_description</depend>
-  <depend>turtlebot3_gazebo</depend>
   <depend>turtlebot3_navigation</depend>
   <exec_depend>gazebo</exec_depend>
   <export>


### PR DESCRIPTION
*Issue #:* https://github.com/aws-robotics/aws-robomaker-sample-application-cloudwatch/issues/26

*Description of changes:*

This removes `turtlebot3` packages from the `.rosinstall` file, so that these packages are no longer obtained by source code through `rosws update`, but rather directly by binary through `rosdep install`, which should be the preferred method.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
