### PR TITLE
Remove turtlebot3 from dependency

### DIFF
--- a/simulation_ws/src/cloudwatch_simulation/package.xml
+++ b/simulation_ws/src/cloudwatch_simulation/package.xml
@@ -16,7 +16,7 @@
   <depend>tf2</depend>
   <depend>gazebo_ros</depend>
   <depend>gazebo_plugins</depend>
-  <depend>turtlebot3</depend>
+  <depend>robot_state_publisher</depend>
   <depend>nav2_bringup</depend>
   <export>
     <build_type>ament_python</build_type>


### PR DESCRIPTION
Changes
- Removed turtlebot3 dependencies in package.xml
- Added robot_state_publisher as dependency in package.xml

Tested locally with Gazebo 9 on Ubuntu 18.04 and bundles on Robomaker

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.