### PR TITLE
Add turtlebot3_description in robot workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 simulation_ws/src/aws-robomaker-bookstore-world
 simulation_ws/src/aws-robomaker-small-house-world
 robot_ws/build
+robot_ws/bundle
 robot_ws/install
 robot_ws/log
+robot_ws/src/deps
 simulation_ws/build
 simulation_ws/bundle
 simulation_ws/install

--- a/robot_ws/.rosinstall
+++ b/robot_ws/.rosinstall
@@ -6,3 +6,4 @@
 - git: {local-name: src/deps/cloudwatchmetrics-ros1, uri: 'https://github.com/aws-robotics/cloudwatchmetrics-ros1', version: 'master'}
 - git: {local-name: src/deps/health-metrics-collector-ros1, uri: 'https://github.com/aws-robotics/health-metrics-collector-ros1', version: 'release-latest'}
 - git: {local-name: src/deps/monitoringmessages-ros1, uri: 'https://github.com/aws-robotics/monitoringmessages-ros1', version: 'release-latest'}
+- git: {local-name: src/deps/turtlebot3-description-reduced-mesh, uri: "https://github.com/aws-robotics/turtlebot3-description-reduced-mesh.git", version: "ros1"}

--- a/robot_ws/src/cloudwatch_robot/CMakeLists.txt
+++ b/robot_ws/src/cloudwatch_robot/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(catkin REQUIRED COMPONENTS
   cloudwatch_metrics_collector
   cloudwatch_logger
   health_metric_collector
+  turtlebot3_description # required to install .rviz model
 )
 
 ################################################################################
@@ -85,6 +86,11 @@ install(DIRECTORY deploymentScripts
   DESTINATION ${CATKIN_GLOBAL_SHARE_DESTINATION}
 )
 
+# Copy the rviz model for easier access in AWS RoboMaker RViz 
+install(FILES ${turtlebot3_description_DIR}/../rviz/model.rviz
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/rviz
+  RENAME turtlebot3_model.rviz
+)
 ################################################################################
 # Test
 ################################################################################

--- a/robot_ws/src/cloudwatch_robot/launch/await_commands.launch
+++ b/robot_ws/src/cloudwatch_robot/launch/await_commands.launch
@@ -19,6 +19,10 @@
   <arg name="use_sim_time" default="true"/>
   <param name="use_sim_time" value="$(arg use_sim_time)"/>
 
+  <!-- Optional environment variable, default is "waffle_pi". Note that "burger" does not have a camera -->
+  <arg name="model" default="$(optenv TURTLEBOT3_MODEL waffle_pi)" doc="model type [burger, waffle, waffle_pi]"/>
+  <param name="robot_description" command="$(find xacro)/xacro --inorder $(find turtlebot3_description)/urdf/turtlebot3_$(arg model).urdf.xacro" />
+
   <!-- Enable Monitoring -->
   <include file="$(find cloudwatch_robot)/launch/monitoring.launch"/>
 

--- a/robot_ws/src/cloudwatch_robot/launch/await_commands.launch
+++ b/robot_ws/src/cloudwatch_robot/launch/await_commands.launch
@@ -21,7 +21,7 @@
 
   <!-- Optional environment variable, default is "waffle_pi". Note that "burger" does not have a camera -->
   <arg name="model" default="$(optenv TURTLEBOT3_MODEL waffle_pi)" doc="model type [burger, waffle, waffle_pi]"/>
-  <param name="robot_description" command="$(find xacro)/xacro --inorder $(find turtlebot3_description)/urdf/turtlebot3_$(arg model).urdf.xacro" />
+  <param name="robot_description" command="$(find xacro)/xacro --inorder $(find turtlebot3_description_reduced_mesh)/urdf/turtlebot3_$(arg model).urdf.xacro" />
 
   <!-- Enable Monitoring -->
   <include file="$(find cloudwatch_robot)/launch/monitoring.launch"/>

--- a/robot_ws/src/cloudwatch_robot/launch/rotate.launch
+++ b/robot_ws/src/cloudwatch_robot/launch/rotate.launch
@@ -15,6 +15,10 @@
   <arg name="use_sim_time" default="true"/>
   <param name="use_sim_time" value="$(arg use_sim_time)"/>
 
+  <!-- Optional environment variable, default is "waffle_pi". Note that "burger" does not have a camera -->
+  <arg name="model" default="$(optenv TURTLEBOT3_MODEL waffle_pi)" doc="model type [burger, waffle, waffle_pi]"/>
+  <param name="robot_description" command="$(find xacro)/xacro --inorder $(find turtlebot3_description)/urdf/turtlebot3_$(arg model).urdf.xacro" />
+
   <!-- Enable Monitoring -->
   <include file="$(find cloudwatch_robot)/launch/monitoring.launch"/>
 

--- a/robot_ws/src/cloudwatch_robot/launch/rotate.launch
+++ b/robot_ws/src/cloudwatch_robot/launch/rotate.launch
@@ -17,7 +17,7 @@
 
   <!-- Optional environment variable, default is "waffle_pi". Note that "burger" does not have a camera -->
   <arg name="model" default="$(optenv TURTLEBOT3_MODEL waffle_pi)" doc="model type [burger, waffle, waffle_pi]"/>
-  <param name="robot_description" command="$(find xacro)/xacro --inorder $(find turtlebot3_description)/urdf/turtlebot3_$(arg model).urdf.xacro" />
+  <param name="robot_description" command="$(find xacro)/xacro --inorder $(find turtlebot3_description_reduced_mesh)/urdf/turtlebot3_$(arg model).urdf.xacro" />
 
   <!-- Enable Monitoring -->
   <include file="$(find cloudwatch_robot)/launch/monitoring.launch"/>

--- a/robot_ws/src/cloudwatch_robot/package.xml
+++ b/robot_ws/src/cloudwatch_robot/package.xml
@@ -35,5 +35,6 @@
 
   <!-- Turtlebot -->
   <depend>turtlebot3_msgs</depend>
+  <!-- Required to install .rviz model-->
   <depend>turtlebot3_description</depend>
 </package>

--- a/robot_ws/src/cloudwatch_robot/package.xml
+++ b/robot_ws/src/cloudwatch_robot/package.xml
@@ -37,4 +37,6 @@
   <depend>turtlebot3_msgs</depend>
   <!-- Required to install .rviz model-->
   <depend>turtlebot3_description</depend>
+
+  <depend>turtlebot3_description_reduced_mesh</depend>
 </package>

--- a/robot_ws/src/cloudwatch_robot/package.xml
+++ b/robot_ws/src/cloudwatch_robot/package.xml
@@ -35,4 +35,5 @@
 
   <!-- Turtlebot -->
   <depend>turtlebot3_msgs</depend>
+  <depend>turtlebot3_description</depend>
 </package>


### PR DESCRIPTION
Issue #, if available:
Currently, robot model is not visible in rviz because the parameter robot_description hasn't been created.

Description of changes:
This PR adds turtlebot3_description as a dependency in robot workspace, and create the parameter robot_description correctly in rotate.launch

Tested both locally and on AWS Robomaker.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.