### PR TITLE
Disable rviz in launch file ros2

### DIFF
--- a/simulation_ws/src/cloudwatch_simulation/launch/bookstore_turtlebot_navigation.launch.py
+++ b/simulation_ws/src/cloudwatch_simulation/launch/bookstore_turtlebot_navigation.launch.py
@@ -76,7 +76,7 @@ def generate_launch_description():
             launch_arguments={
                 'map_file': os.path.join(get_package_share_directory('cloudwatch_simulation'), 'maps', 'map.yaml'),
                 'params_file': os.path.join(get_package_share_directory('cloudwatch_simulation'), 'param', TURTLEBOT3_MODEL + ".yaml"),
-                'open_rviz': launch.substitutions.LaunchConfiguration('gui'),
+                'open_rviz': 'false',
                 'use_sim_time': launch.substitutions.LaunchConfiguration('use_sim_time')
             }.items()
         ),


### PR DESCRIPTION
Do not run rviz even when `gui:=true`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
