### PR TITLE
Add turltebot3-description-reduced-mesh as dependency

### DIFF
--- a/robot_ws/.rosinstall
+++ b/robot_ws/.rosinstall
@@ -1,1 +1,1 @@
-
+- git: {local-name: src/deps/turtlebot3-description-reduced-mesh, uri: "https://github.com/aws-robotics/turtlebot3-description-reduced-mesh.git", version: "ros2"}


### PR DESCRIPTION
Add turtlebot3-description-reduced-mesh in .rosinstall for robot model reference. It enables robot model to be successfully loaded in rviz.

Tested locally and on AWS RoboMaker via bundles.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.