### PR TITLE
Update GitHub action version for ros2

### DIFF
--- a/.github/workflows/ros2.yml
+++ b/.github/workflows/ros2.yml
@@ -34,7 +34,7 @@ jobs:
         sudo chown -R rosbuild:rosbuild "$HOME" .
     - id: robot_ws_build
       name: Build and Bundle Robot Workspace
-      uses: aws-robotics/aws-robomaker-github-actions/robomaker-sample-app-ci@2.0.0
+      uses: aws-robotics/aws-robomaker-github-actions/robomaker-sample-app-ci@2.1.0
       with:
         ros-distro: ${{ matrix.distro }}
         gazebo-version: ${{ matrix.gazebo }}
@@ -42,7 +42,7 @@ jobs:
         generate-sources: true
     - id: simulation_ws_build
       name: Build and Bundle Simulation Workspace
-      uses: aws-robotics/aws-robomaker-github-actions/robomaker-sample-app-ci@2.0.0
+      uses: aws-robotics/aws-robomaker-github-actions/robomaker-sample-app-ci@2.1.0
       with:
         ros-distro: ${{ matrix.distro }}
         gazebo-version: ${{ matrix.gazebo }}


### PR DESCRIPTION
Updating github-action version to 2.1.0 to include [this fix](https://github.com/aws-robotics/aws-robomaker-github-actions/commit/53b6be753b5a5995028794b4ab4aa69d0402584f).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
