### PR TITLE
Move robot_state_publisher from sim_ws to robot_ws

### DIFF
--- a/robot_ws/src/cloudwatch_robot/launch/await_commands.launch.py
+++ b/robot_ws/src/cloudwatch_robot/launch/await_commands.launch.py
@@ -5,7 +5,12 @@ import launch
 import launch_ros.actions
 from ament_index_python.packages import get_package_share_directory
 
+TURTLEBOT3_MODEL = os.environ.get('TURTLEBOT3_MODEL', 'waffle_pi')
+
 def generate_launch_description():
+    turtlebot_urdf_file_name = 'turtlebot3_' + TURTLEBOT3_MODEL + '.urdf'
+    turtlebot_urdf_file_path = os.path.join(get_package_share_directory('turtlebot3_description_reduced_mesh'), 'urdf', turtlebot_urdf_file_name)
+
     launch_actions = [
         launch.actions.DeclareLaunchArgument(
             name='use_sim_time',
@@ -15,7 +20,18 @@ def generate_launch_description():
             launch.launch_description_sources.PythonLaunchDescriptionSource(
                 os.path.join(get_package_share_directory('cloudwatch_robot'), 'launch', 'monitoring.launch.py')
             )
-        )
+        ),
+        launch_ros.actions.Node(
+            package='robot_state_publisher',
+            node_executable='robot_state_publisher',
+            node_name='robot_state_publisher',
+            output='screen',
+            parameters=[{
+                'use_sim_time': launch.substitutions.LaunchConfiguration('use_sim_time')
+            }],
+            arguments=[
+                turtlebot_urdf_file_path
+            ])
     ]
     ld = launch.LaunchDescription(launch_actions)
     return ld

--- a/robot_ws/src/cloudwatch_robot/launch/rotate.launch.py
+++ b/robot_ws/src/cloudwatch_robot/launch/rotate.launch.py
@@ -4,8 +4,13 @@ import sys
 import launch
 import launch_ros.actions
 from ament_index_python.packages import get_package_share_directory
+ 
+TURTLEBOT3_MODEL = os.environ.get('TURTLEBOT3_MODEL', 'waffle_pi')
 
 def generate_launch_description():
+    turtlebot_urdf_file_name = 'turtlebot3_' + TURTLEBOT3_MODEL + '.urdf'
+    turtlebot_urdf_file_path = os.path.join(get_package_share_directory('turtlebot3_description_reduced_mesh'), 'urdf', turtlebot_urdf_file_name)
+
     launch_actions = [
         launch.actions.DeclareLaunchArgument(
             name='use_sim_time',
@@ -26,7 +31,18 @@ def generate_launch_description():
                     'use_sim_time': launch.substitutions.LaunchConfiguration('use_sim_time')
                 }
             ]
-        )
+        ),
+        launch_ros.actions.Node(
+            package='robot_state_publisher',
+            node_executable='robot_state_publisher',
+            node_name='robot_state_publisher',
+            output='screen',
+            parameters=[{
+                'use_sim_time': launch.substitutions.LaunchConfiguration('use_sim_time')
+            }],
+            arguments=[
+                turtlebot_urdf_file_path
+            ])
     ]
     ld = launch.LaunchDescription(launch_actions)
     return ld

--- a/robot_ws/src/cloudwatch_robot/package.xml
+++ b/robot_ws/src/cloudwatch_robot/package.xml
@@ -24,6 +24,8 @@
   <depend>turtlebot3</depend>
   <depend>turtlebot3_msgs</depend>
   <depend>builtin_interfaces</depend>
+  <depend>robot_state_publisher</depend>
+  <depend>turtlebot3_description_reduced_mesh</depend>
 
   <exec_depend>launch</exec_depend>
   <exec_depend>launch_ros</exec_depend>

--- a/simulation_ws/src/cloudwatch_simulation/launch/bookstore_turtlebot_navigation.launch.py
+++ b/simulation_ws/src/cloudwatch_simulation/launch/bookstore_turtlebot_navigation.launch.py
@@ -8,9 +8,6 @@ from ament_index_python.packages import get_package_share_directory
 TURTLEBOT3_MODEL = os.environ.get('TURTLEBOT3_MODEL', 'burger')
 
 def generate_launch_description():
-    turtlebot_urdf_file_name = 'turtlebot3_' + TURTLEBOT3_MODEL + '.urdf'
-    turtlebot_urdf_file_path = os.path.join(get_package_share_directory('turtlebot3_description_reduced_mesh'), 'urdf', turtlebot_urdf_file_name)
-
     ld = launch.LaunchDescription([
         launch.actions.DeclareLaunchArgument(
             name='x_pos',
@@ -52,18 +49,6 @@ def generate_launch_description():
                 'gui': launch.substitutions.LaunchConfiguration('gui'),
                 'gazebo_model_path': os.path.split(get_package_share_directory('turtlebot3_description_reduced_mesh'))[0],
             }.items()
-        ),
-        launch_ros.actions.Node(
-            package='robot_state_publisher',
-            node_executable='robot_state_publisher',
-            node_name='robot_state_publisher',
-            output='screen',
-            parameters=[{
-                'use_sim_time': launch.substitutions.LaunchConfiguration('use_sim_time')
-            }],
-            arguments=[
-                turtlebot_urdf_file_path
-            ]
         ),
         launch.actions.IncludeLaunchDescription(
             launch.launch_description_sources.PythonLaunchDescriptionSource(

--- a/simulation_ws/src/cloudwatch_simulation/package.xml
+++ b/simulation_ws/src/cloudwatch_simulation/package.xml
@@ -16,8 +16,8 @@
   <depend>tf2</depend>
   <depend>gazebo_ros</depend>
   <depend>gazebo_plugins</depend>
-  <depend>robot_state_publisher</depend>
   <depend>nav2_bringup</depend>
+  <depend>turtlebot3_description_reduced_mesh</depend>
   <export>
     <build_type>ament_python</build_type>
     <gazebo_ros gazebo_media_path="${prefix}/worlds"/>


### PR DESCRIPTION
Moving ROS node `robot_state_publisher` from simulation workspace to robot workspace. Tested both locally and on robomaker with bundles that robot model is visible in rviz when running robot application alone.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.