### PR TITLE
Remove aws credentials from build and bundle GH workflow - ros2

### DIFF
--- a/.github/workflows/ros2.yml
+++ b/.github/workflows/ros2.yml
@@ -47,13 +47,6 @@ jobs:
         ros-distro: ${{ matrix.distro }}
         gazebo-version: ${{ matrix.gazebo }}
         workspace-dir: simulation_ws
-    - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_ROS2 }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ROS2 }}
-        aws-region: ${{ secrets.AWS_REGION }}
-      if: always() && github.ref == 'refs/heads/ros2' # always for "push" and "schedule" build status
 
   log_workflow_status_to_cloudwatch:
     runs-on: ubuntu-latest


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Remove the unnecessary AWS credentials step from build and bundle job for ros2 GH workflows.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
