### PR TITLE
Add turtlebot3_bringup as a dependency

### DIFF
--- a/robot_ws/src/cloudwatch_robot/package.xml
+++ b/robot_ws/src/cloudwatch_robot/package.xml
@@ -35,7 +35,8 @@
   <!-- Turtlebot -->
   <depend>turtlebot3_msgs</depend>
   <depend>robot_state_publisher</depend>
-
+  
+  <exec_depend>turtlebot3_bringup</exec_depend>
   <!-- Required to install .rviz model-->
   <depend>turtlebot3_description</depend>
 


### PR DESCRIPTION
*Issue #, if available:*
Package `turtlebot3_bringup` is required when deploying robot application on a physical robot.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
