### PR TITLE
Add missing launch file in setup.py

### DIFF
--- a/robot_ws/src/cloudwatch_robot/setup.py
+++ b/robot_ws/src/cloudwatch_robot/setup.py
@@ -12,6 +12,7 @@ setup(
         ('share/' + package_name + '/launch', ['launch/deploy_rotate.launch.py']),
         ('share/' + package_name + '/launch', ['launch/monitoring.launch.py']),
         ('share/' + package_name + '/launch', ['launch/rotate.launch.py']),
+        ('share/' + package_name + '/launch', ['launch/deploy_await_commands.launch.py']),
         ('share/' + package_name + '/config', ['config/cloudwatch_logs_config.yaml']),
         ('share/' + package_name + '/config', ['config/cloudwatch_metrics_config.yaml']),
         ('share/' + package_name + '/config', ['config/health_metrics_config.yaml']),


### PR DESCRIPTION
`deploy_await_commands.launch.py` is missing in setup.py

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
