### PR TITLE
Rollback aws-actions/configure-aws-credentials to v1.5.2 for a fix

### DIFF
--- a/.github/workflows/ros1.yml
+++ b/.github/workflows/ros1.yml
@@ -57,7 +57,7 @@ jobs:
         gazebo-version: ${{ matrix.gazebo }}
         workspace-dir: simulation_ws
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v1.5.2
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_ROS1 }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ROS1 }}
@@ -98,7 +98,7 @@ jobs:
     if: ${{ always() && github.event_name != 'pull_request' }}
     steps:
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v1.5.2
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_ROS1 }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ROS1 }}

--- a/.github/workflows/ros2.yml
+++ b/.github/workflows/ros2.yml
@@ -50,7 +50,7 @@ jobs:
         gazebo-version: ${{ matrix.gazebo }}
         workspace-dir: simulation_ws
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v1.5.2
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_ROS2 }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ROS2 }}
@@ -93,7 +93,7 @@ jobs:
     if: ${{ always() && github.event_name != 'pull_request' }}
     steps:
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v1.5.2
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_ROS2 }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ROS2 }}


### PR DESCRIPTION
*Issue #, if available:*
Version v1 points to v1.5.3 which causes the following failure:
https://github.com/aws-robotics/aws-robomaker-sample-application-cloudwatch/actions/runs/291541380
https://github.com/aws-robotics/aws-robomaker-sample-application-cloudwatch/actions/runs/291557349

*Description of changes:*
Rollback to previous stable version, which is v1.5.2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
