### PR TITLE
Create a template launch file for navigation and add small house worl…

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Launch the application with the following commands:
     There are two simulation launch commands for two different worlds:
     - `empty_world.launch.py` - Empty world with some balls surrounding the turtlebot at (0,0)
     - `bookstore_turtlebot_navigation.launch.py` - A retail space where the robot navigates to random goals
+    - `small_house_turtlebot_navigation.launch.py` - A small house where the robot navigates to random goals
 
 ![CloudWatchMetrics01.png](docs/images/BookstoreRVizPlan01.png)
 

--- a/simulation_ws/.rosinstall
+++ b/simulation_ws/.rosinstall
@@ -1,3 +1,4 @@
 - git: {local-name: src/deps/aws-robomaker-bookstore-world, uri: "https://github.com/aws-robotics/aws-robomaker-bookstore-world", version: ros2}
+- git: {local-name: src/deps/aws-robomaker-small-house-world, uri: "https://github.com/aws-robotics/aws-robomaker-small-house-world", version: ros2}
 - git: {local-name: src/deps/turtlebot3-description-reduced-mesh, uri: "https://github.com/aws-robotics/turtlebot3-description-reduced-mesh.git", version: "ros2"}
 - git: {local-name: src/deps/gazebo-ros-pkgs, uri: "https://github.com/ros-simulation/gazebo_ros_pkgs.git", version: "c071749932a541a5b8aced23c3414724a8cd1949"}

--- a/simulation_ws/src/cloudwatch_simulation/launch/bookstore.launch.py
+++ b/simulation_ws/src/cloudwatch_simulation/launch/bookstore.launch.py
@@ -9,6 +9,18 @@ from ament_index_python.packages import get_package_share_directory
 def generate_launch_description():
     ld = launch.LaunchDescription([
         launch.actions.DeclareLaunchArgument(
+            name='x_pos',
+            default_value='-3.5'
+        ),
+        launch.actions.DeclareLaunchArgument(
+            name='y_pos',
+            default_value='5.5'
+        ),
+        launch.actions.DeclareLaunchArgument(
+            name='z_pos',
+            default_value='0.30'
+        ),
+        launch.actions.DeclareLaunchArgument(
             name='gui',
             default_value='false'
         ),
@@ -27,9 +39,9 @@ def generate_launch_description():
                     'turtlebot3_description_reduced_mesh'), 'launch', 'spawn_turtlebot.launch.py')
             ),
             launch_arguments={
-                'x_pos': '-3.5',
-                'y_pos': '5.5',
-                'z_pos': '0.3'
+                'x_pos': launch.substitutions.LaunchConfiguration('x_pos'),
+                'y_pos': launch.substitutions.LaunchConfiguration('y_pos'),
+                'z_pos': launch.substitutions.LaunchConfiguration('z_pos')
             }.items()
         )
     ])

--- a/simulation_ws/src/cloudwatch_simulation/launch/bookstore_turtlebot_navigation.launch.py
+++ b/simulation_ws/src/cloudwatch_simulation/launch/bookstore_turtlebot_navigation.launch.py
@@ -25,7 +25,7 @@ def generate_launch_description():
                 os.path.join(
                     get_package_share_directory('cloudwatch_simulation'),
                     'launch',
-                    'world_turtlebot_navigation.launch.py'
+                    'sample_world_turtlebot_navigation.launch.py'
                 )
             ),
             launch_arguments={

--- a/simulation_ws/src/cloudwatch_simulation/launch/sample_world_turtlebot_navigation.launch.py
+++ b/simulation_ws/src/cloudwatch_simulation/launch/sample_world_turtlebot_navigation.launch.py
@@ -1,8 +1,11 @@
 # *******************************************************************************/
 # This launch file serves as a template for navigation launch files.
-# It takes two key argument:
-# - world_launch_file, which specifies the world launch file name
-# - world_package, which specifies the actual package name that stores the world
+# It takes five non-optional arguments:
+# - x_pos            : The x coordinate of the robot initial pose
+# - y_pos            : The y coordinate of the robot initial pose
+# - z_pos            : The z coordinate of the robot initial pose
+# - world_launch_file: It specifies the world launch file name
+# - world_package    : It specifies the actual package name that stores the world
 # *******************************************************************************/
 import os
 import sys
@@ -17,15 +20,15 @@ def generate_launch_description():
     ld = launch.LaunchDescription([
         launch.actions.DeclareLaunchArgument(
             name='x_pos',
-            default_value='-3.5'
+            description='The x coordinate of the robot initial pose'
         ),
         launch.actions.DeclareLaunchArgument(
             name='y_pos',
-            default_value='5.5'
+            description='The y coordinate of the robot initial pose'
         ),
         launch.actions.DeclareLaunchArgument(
             name='z_pos',
-            default_value='0.30'
+            description='The z coordinate of the robot initial pose'
         ),
         launch.actions.DeclareLaunchArgument(
             name='yaw',
@@ -45,11 +48,11 @@ def generate_launch_description():
         ),
         launch.actions.DeclareLaunchArgument(
             name='world_launch_file',
-            default_value='bookstore.launch.py'
+            description='The world launch file'
         ),
         launch.actions.DeclareLaunchArgument(
             name='world_package',
-            default_value='aws_robomaker_bookstore_world'
+            description='The package that stores the world launch file'
         ),
         launch.actions.IncludeLaunchDescription(
             launch.launch_description_sources.PythonLaunchDescriptionSource(

--- a/simulation_ws/src/cloudwatch_simulation/launch/small_house_turtlebot_navigation.launch.py
+++ b/simulation_ws/src/cloudwatch_simulation/launch/small_house_turtlebot_navigation.launch.py
@@ -25,7 +25,7 @@ def generate_launch_description():
                 os.path.join(
                     get_package_share_directory('cloudwatch_simulation'),
                     'launch',
-                    'world_turtlebot_navigation.launch.py'
+                    'sample_world_turtlebot_navigation.launch.py'
                 )
             ),
             launch_arguments={

--- a/simulation_ws/src/cloudwatch_simulation/launch/small_house_turtlebot_navigation.launch.py
+++ b/simulation_ws/src/cloudwatch_simulation/launch/small_house_turtlebot_navigation.launch.py
@@ -10,11 +10,11 @@ def generate_launch_description():
     ld = launch.LaunchDescription([
         launch.actions.DeclareLaunchArgument(
             name='x_pos',
-            default_value='-3.5'
+            default_value='3.3'
         ),
         launch.actions.DeclareLaunchArgument(
             name='y_pos',
-            default_value='5.5'
+            default_value='-1.7'
         ),
         launch.actions.DeclareLaunchArgument(
             name='z_pos',
@@ -29,8 +29,8 @@ def generate_launch_description():
                 )
             ),
             launch_arguments={
-                'world_launch_file': 'bookstore.launch.py',
-                'world_package': 'aws_robomaker_bookstore_world',
+                'world_launch_file': 'small_house_world.launch.py',
+                'world_package': 'aws_robomaker_small_house_world',
                 'x_pos': launch.substitutions.LaunchConfiguration('x_pos'),
                 'y_pos': launch.substitutions.LaunchConfiguration('y_pos'),
                 'z_pos': launch.substitutions.LaunchConfiguration('z_pos')

--- a/simulation_ws/src/cloudwatch_simulation/launch/small_house_world.launch.py
+++ b/simulation_ws/src/cloudwatch_simulation/launch/small_house_world.launch.py
@@ -10,27 +10,35 @@ def generate_launch_description():
     ld = launch.LaunchDescription([
         launch.actions.DeclareLaunchArgument(
             name='x_pos',
-            default_value='-3.5'
+            default_value='3.3'
         ),
         launch.actions.DeclareLaunchArgument(
             name='y_pos',
-            default_value='5.5'
+            default_value='-1.7'
         ),
         launch.actions.DeclareLaunchArgument(
             name='z_pos',
-            default_value='0.30'
+            default_value='0.3'
+        ),
+        launch.actions.DeclareLaunchArgument(
+            name='gui',
+            default_value='false'
         ),
         launch.actions.IncludeLaunchDescription(
             launch.launch_description_sources.PythonLaunchDescriptionSource(
-                os.path.join(
-                    get_package_share_directory('cloudwatch_simulation'),
-                    'launch',
-                    'world_turtlebot_navigation.launch.py'
-                )
+                os.path.join(get_package_share_directory(
+                    'aws_robomaker_small_house_world'), 'launch', 'small_house.launch.py')
             ),
             launch_arguments={
-                'world_launch_file': 'bookstore.launch.py',
-                'world_package': 'aws_robomaker_bookstore_world',
+                'gui': launch.substitutions.LaunchConfiguration('gui')
+            }.items()
+        ),
+        launch.actions.IncludeLaunchDescription(
+            launch.launch_description_sources.PythonLaunchDescriptionSource(
+                os.path.join(get_package_share_directory(
+                    'turtlebot3_description_reduced_mesh'), 'launch', 'spawn_turtlebot.launch.py')
+            ),
+            launch_arguments={
                 'x_pos': launch.substitutions.LaunchConfiguration('x_pos'),
                 'y_pos': launch.substitutions.LaunchConfiguration('y_pos'),
                 'z_pos': launch.substitutions.LaunchConfiguration('z_pos')

--- a/simulation_ws/src/cloudwatch_simulation/launch/world_turtlebot_navigation.launch.py
+++ b/simulation_ws/src/cloudwatch_simulation/launch/world_turtlebot_navigation.launch.py
@@ -1,0 +1,99 @@
+# *******************************************************************************/
+# This launch file serves as a template for navigation launch files.
+# It takes two key argument:
+# - world_launch_file, which specifies the world launch file name
+# - world_package, which specifies the actual package name that stores the world
+# *******************************************************************************/
+import os
+import sys
+
+import launch
+import launch_ros.actions
+from ament_index_python.packages import get_package_share_directory
+
+TURTLEBOT3_MODEL = os.environ.get('TURTLEBOT3_MODEL', 'waffle_pi')
+
+def generate_launch_description():
+    ld = launch.LaunchDescription([
+        launch.actions.DeclareLaunchArgument(
+            name='x_pos',
+            default_value='-3.5'
+        ),
+        launch.actions.DeclareLaunchArgument(
+            name='y_pos',
+            default_value='5.5'
+        ),
+        launch.actions.DeclareLaunchArgument(
+            name='z_pos',
+            default_value='0.30'
+        ),
+        launch.actions.DeclareLaunchArgument(
+            name='yaw',
+            default_value='0.0'
+        ),
+        launch.actions.DeclareLaunchArgument(
+            name='gui',
+            default_value='false'
+        ),
+        launch.actions.DeclareLaunchArgument(
+            name='follow_route',
+            default_value='true'
+        ),
+        launch.actions.DeclareLaunchArgument(
+            name='use_sim_time',
+            default_value='true'
+        ),
+        launch.actions.DeclareLaunchArgument(
+            name='world_launch_file',
+            default_value='bookstore.launch.py'
+        ),
+        launch.actions.DeclareLaunchArgument(
+            name='world_package',
+            default_value='aws_robomaker_bookstore_world'
+        ),
+        launch.actions.IncludeLaunchDescription(
+            launch.launch_description_sources.PythonLaunchDescriptionSource(
+                [
+                    get_package_share_directory('cloudwatch_simulation'),
+                    '/launch/',
+                    launch.substitutions.LaunchConfiguration('world_launch_file')
+                ]
+            ),
+            launch_arguments={
+                'gui': launch.substitutions.LaunchConfiguration('gui'),
+                'gazebo_model_path': os.path.split(get_package_share_directory('turtlebot3_description_reduced_mesh'))[0],
+            }.items()
+        ),
+        launch.actions.IncludeLaunchDescription(
+            launch.launch_description_sources.PythonLaunchDescriptionSource(
+                os.path.join(
+                    get_package_share_directory('cloudwatch_simulation'),
+                    'launch',
+                    'turtlebot3_navigation.launch.py'
+                )
+            ),
+            launch_arguments={
+                'map_file': os.path.join(get_package_share_directory('cloudwatch_simulation'), 'maps', 'map.yaml'),
+                'params_file': os.path.join(get_package_share_directory('cloudwatch_simulation'), 'param', TURTLEBOT3_MODEL + ".yaml"),
+                'open_rviz': 'false',
+                'use_sim_time': launch.substitutions.LaunchConfiguration('use_sim_time')
+            }.items()
+        ),
+        launch_ros.actions.Node(
+            package='aws_robomaker_simulation_common',
+            node_executable='route_manager',
+            node_name='route_manager',
+            output='screen',
+            parameters=[{
+                # Route file is passed as "<package_name>.<relative path in install space>" due to limitations on string parameter size.
+                'route_file': [launch.substitutions.LaunchConfiguration('world_package'), '.', os.path.join('routes', 'route.yaml')]
+            }],
+            condition=launch.conditions.IfCondition(
+                launch.substitutions.LaunchConfiguration('follow_route'))
+        )
+    ])
+    return ld
+
+
+if __name__ == '__main__':
+    generate_launch_description()


### PR DESCRIPTION
* Creates a template launch file for navigation so future launch files can be added easily.
* Include small house world as a dependency.
* Make initial pose configurable in the world launch files.
* Embed navigation launch files for [small house world](https://github.com/aws-robotics/aws-robomaker-small-house-world) into this repo, for the purpose of making small house world a pure world repository.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
