### PR TITLE
Fix package for turtlebot3_navigation.launch

### DIFF
--- a/simulation_ws/src/cloudwatch_simulation/launch/bookstore_turtlebot_navigation.launch
+++ b/simulation_ws/src/cloudwatch_simulation/launch/bookstore_turtlebot_navigation.launch
@@ -53,7 +53,7 @@
   </include>
 
   <!-- Enable navigation system -->
-  <include file="$(find aws_robomaker_bookstore_world)/launch/turtlebot3_navigation.launch">
+  <include file="$(find cloudwatch_simulation)/launch/turtlebot3_navigation.launch">
     <arg name="map_file" value="$(find aws_robomaker_bookstore_world)/maps/turtlebot3_$(arg model)/map.yaml"/>
     <!-- Initial pose must match the starting position of the robot for an aligned map -->
     <arg name="initial_pose_x" value="$(arg x_pos)"/>


### PR DESCRIPTION
*Issue #, if available:*
The package of turtlebot3_navigation.launch in bookstore_turtlebot_navigation.launch should be cloudwatch_simulation.

*Description of changes:*
Fix the package for turtlebot3_navigation.launch to be cloudwatch_simulation.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
