### PR TITLE
Adding DescribeLogGroups as required permission in the IAM role

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ You will need to create an AWS Account and configure the credentials to be able 
 To run this application you will need an IAM user with the following permissions:
 ```
    logs:PutLogEvents
+   logs:DescribeLogGroups
    logs:DescribeLogStreams
    logs:CreateLogStream
    logs:CreateLogGroup
@@ -38,6 +39,7 @@ You can find instructions for creating a new IAM Policy [here](https://docs.aws.
       "Action": [
         "cloudwatch:PutMetricData",
         "logs:PutLogEvents",
+        "logs:DescribeLogGroups",
         "logs:DescribeLogStreams",
         "logs:CreateLogStream",
         "logs:CreateLogGroup"


### PR DESCRIPTION
*Description of changes:*
- Adds `logs:DescribeLogGroups` as a required permission to run the `cloudwatch_logger` within the robot app.
- Tracking changes from aws-robotics/cloudwatchlogs-ros1#75

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
