### PR TITLE
Fix logic for determining pass/fail of workspace build (ROS1)

### DIFF
--- a/.github/workflows/ros1.yml
+++ b/.github/workflows/ros1.yml
@@ -64,20 +64,20 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_ROS1 }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ROS1 }}
         aws-region: ${{ secrets.AWS_REGION }}
-      if: ${{ github.event_name == 'schedule' &&  !contains(steps.robot_ws_build.outcome, 'failure') && !contains(steps.simulation_ws_build.outcome, 'failure') }}
-    - id: deploy_bundle
-      name: Deploy bundle to S3
+      if: ${{ github.event_name == 'schedule' &&  contains(steps.robot_ws_build.outcome, 'success') && contains(steps.simulation_ws_build.outcome, 'success') }}
+    - id: upload_bundle
+      name: Upload bundle to S3
       uses: aws-robotics/aws-robomaker-github-actions/s3-cp-action@2.4.1
       env:
         AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET_ROS1 }}
         AWS_REGION: ${{ secrets.AWS_REGION }}
         FILES: 'sources.zip sources.tar.gz robot_ws.tar simulation_ws.tar'
         DEST: 'travis/cloudwatch/${{ steps.robot_ws_build.outputs.ros-distro }}/${{ steps.robot_ws_build.outputs.gazebo-version }}/${{ steps.robot_ws_build.outputs.sample-app-version }}.${{ github.run_number }}/'
-      if: ${{ github.event_name == 'schedule' && !contains(steps.robot_ws_build.outcome, 'failure') && !contains(steps.simulation_ws_build.outcome, 'failure') }} # upload to S3 on "schedule" build if the build was successful
+      if: ${{ github.event_name == 'schedule' && contains(steps.robot_ws_build.outcome, 'success') && contains(steps.simulation_ws_build.outcome, 'success') }} # upload to S3 on "schedule" build if the build was successful
     - name: Get time stamp
       id: time
       run: echo "::set-output name=timestamp::$(date +%s)"
-      if: ${{ github.event_name == 'schedule' && !contains(steps.robot_ws_build.outcome, 'failure') && !contains(steps.simulation_ws_build.outcome, 'failure') }}
+      if: ${{ github.event_name == 'schedule' && contains(steps.robot_ws_build.outcome, 'success') && contains(steps.simulation_ws_build.outcome, 'success') }}
     - name: Update App-manifest version number
       id: update-app-manifest
       uses: aws-robotics/aws-robomaker-github-actions/codecommit-put-file-action@2.4.1
@@ -89,7 +89,7 @@ jobs:
         COMMIT_MSG: 'Updating to version ${{ steps.robot_ws_build.outputs.sample-app-version }}.${{ github.run_number }}. Commit for this version bump: ${{ github.sha }}.'
         USER_EMAIL: 'ros-contributions@amazon.com'
         USER_NAME: 'ros-contributions'
-      if: ${{ github.event_name == 'schedule' && !contains(steps.robot_ws_build.outcome, 'failure') && !contains(steps.simulation_ws_build.outcome, 'failure') }} # Update app-manifest version number if the build was successful
+      if: ${{ github.event_name == 'schedule' && contains(steps.robot_ws_build.outcome, 'success') && contains(steps.simulation_ws_build.outcome, 'success') }} # Update app-manifest version number if the build was successful
 
   log_workflow_status_to_cloudwatch:
     runs-on: ubuntu-latest
@@ -109,10 +109,15 @@ jobs:
       uses: ros-tooling/action-cloudwatch-metrics@0.0.4
       with:
         namespace: RobotWorkspaceBuild
-        metric-value: ${{ ! contains(needs.build_and_bundle_ros1.outputs.robot_ws_build_result, 'failure') }}
+        metric-value: ${{ contains(needs.build_and_bundle_ros1.outputs.robot_ws_build_result, 'success') }}
     - name: Log Simulation Workspace Build Status
       uses: ros-tooling/action-cloudwatch-metrics@0.0.4
       with:
         namespace: SimulationWorkspaceBuild
-        metric-value: ${{ ! contains(needs.build_and_bundle_ros1.outputs.simulation_ws_build_result, 'failure') }}
-    
+        metric-value: ${{ contains(needs.build_and_bundle_ros1.outputs.simulation_ws_build_result, 'success') }}
+    - name: Log Bundle Upload Status
+      uses: ros-tooling/action-cloudwatch-metrics@0.0.4
+      with:
+        namespace: BundleUpload
+        metric-value: ${{ contains(needs.build_and_bundle_ros1.result, 'success') }}
+      if: ${{ github.event_name == 'schedule' }}

--- a/.github/workflows/ros2.yml
+++ b/.github/workflows/ros2.yml
@@ -57,20 +57,20 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_ROS2 }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ROS2 }}
         aws-region: ${{ secrets.AWS_REGION }}
-      if: ${{ github.event_name == 'schedule' && !contains(steps.robot_ws_build.outcome, 'failure') && !contains(steps.simulation_ws_build.outcome, 'failure') }}
-    - id: deploy_bundle
-      name: Deploy bundle to S3
+      if: ${{ github.event_name == 'schedule' && contains(steps.robot_ws_build.outcome, 'success') && contains(steps.simulation_ws_build.outcome, 'success') }}
+    - id: upload_bundle
+      name: Upload bundle to S3
       uses: aws-robotics/aws-robomaker-github-actions/s3-cp-action@2.4.1
       env:
         AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET_ROS2 }}
         AWS_REGION: ${{ secrets.AWS_REGION }}
         FILES: 'sources.zip sources.tar.gz robot_ws.tar simulation_ws.tar'
         DEST: 'travis/cloudwatch/${{ steps.robot_ws_build.outputs.ros-distro }}/${{ steps.robot_ws_build.outputs.gazebo-version }}/${{ steps.robot_ws_build.outputs.sample-app-version }}.${{ github.run_number }}/'
-      if: ${{ github.event_name == 'schedule' && !contains(steps.robot_ws_build.outcome, 'failure') && !contains(steps.simulation_ws_build.outcome, 'failure') }} # upload to S3 on "schedule" build if the build was successful
+      if: ${{ github.event_name == 'schedule' && contains(steps.robot_ws_build.outcome, 'success') && contains(steps.simulation_ws_build.outcome, 'success') }} # upload to S3 on "schedule" build if the build was successful
     - name: Get time stamp
       id: time
       run: echo "::set-output name=timestamp::$(date +%s)"
-      if: ${{ github.event_name == 'schedule' && !contains(steps.robot_ws_build.outcome, 'failure') && !contains(steps.simulation_ws_build.outcome, 'failure') }}
+      if: ${{ github.event_name == 'schedule' && contains(steps.robot_ws_build.outcome, 'success') && contains(steps.simulation_ws_build.outcome, 'success') }}
     - name: Update App-manifest version number
       id: update-app-manifest
       uses: aws-robotics/aws-robomaker-github-actions/codecommit-put-file-action@2.4.1
@@ -82,10 +82,8 @@ jobs:
         COMMIT_MSG: 'Updating to version ${{ steps.robot_ws_build.outputs.sample-app-version }}.${{ github.run_number }}. Commit for this version bump: ${{ github.sha }}.'
         USER_EMAIL: 'ros-contributions@amazon.com'
         USER_NAME: 'ros-contributions'
-      if: ${{ github.event_name == 'schedule' && !contains(steps.robot_ws_build.outcome, 'failure') && !contains(steps.simulation_ws_build.outcome, 'failure') }} # Update app-manifest version number if the build was successful
+      if: ${{ github.event_name == 'schedule' && contains(steps.robot_ws_build.outcome, 'success') && contains(steps.simulation_ws_build.outcome, 'success') }} # Update app-manifest version number if the build was successful
 
-
-      
   log_workflow_status_to_cloudwatch:
     runs-on: ubuntu-latest
     container:
@@ -110,7 +108,7 @@ jobs:
             { "Name": "github.repository", "Value": "${{ github.repository }}" }
           ]
         namespace: RobotWorkspaceBuild
-        metric-value: ${{ ! contains(needs.build_and_bundle_ros2.outputs.robot_ws_build_result, 'failure') }}
+        metric-value: ${{ contains(needs.build_and_bundle_ros2.outputs.robot_ws_build_result, 'success') }}
     - name: Log Simulation Workspace Build Status
       uses: ros-tooling/action-cloudwatch-metrics@0.0.4
       with:
@@ -121,5 +119,16 @@ jobs:
             { "Name": "github.repository", "Value": "${{ github.repository }}" }
           ]
         namespace: SimulationWorkspaceBuild
-        metric-value: ${{ ! contains(needs.build_and_bundle_ros2.outputs.simulation_ws_build_result, 'failure') }}
-    
+        metric-value: ${{ contains(needs.build_and_bundle_ros2.outputs.simulation_ws_build_result, 'success') }}
+    - name: Log Bundle Upload Status
+      uses: ros-tooling/action-cloudwatch-metrics@0.0.4
+      with:
+        metric-dimensions: >-
+          [
+            { "Name": "github.event_name", "Value": "${{ github.event_name }}" },
+            { "Name": "github.ref", "Value": "refs/heads/ros2" },
+            { "Name": "github.repository", "Value": "${{ github.repository }}" }
+          ]
+        namespace: BundleUpload
+        metric-value: ${{ contains(needs.build_and_bundle_ros2.result, 'success') }}
+      if: ${{ github.event_name == 'schedule' }}


### PR DESCRIPTION
*Description of changes:*

We're currently incorrectly reporting `skipped` and `cancelled` workspace builds as successful.

This pull request updates the logic for reporting pass vs fail. It also adds an additional metric on the success/failure of uploading the colcon bundle or the entire flow.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
