### PR TITLE
Corrected call to node test_nodes in test_world.launch

### DIFF
--- a/simulation_ws/src/cloudwatch_simulation/launch/test_world.launch
+++ b/simulation_ws/src/cloudwatch_simulation/launch/test_world.launch
@@ -7,6 +7,6 @@
  <!-- Test node -->
  <param name="SIM_TIMEOUT_SECONDS" type="int" value="$(optenv SIM_TIMEOUT_SECONDS 300)" />
  <param name="NAVIGATION_SUCCESS_COUNT" type="int" value="$(optenv NAVIGATION_SUCCESS_COUNT 1)" />
- <node pkg="test_nodes" type="navigation_test" name="navigation_test" output="screen" required="true" />
+ <node pkg="test_nodes" type="navigation_test.py" name="navigation_test" output="screen" required="true" />
 
 </launch>


### PR DESCRIPTION
When launching test_nodes.launch after following the steps in the original repo, an error would happen in which the test node doesn't recognize "navigation_test". This is because it's missing the .py at the end. Its a simple fix which fixed it for me. 
Without this correction, the world and robot simulation would work, but not the test node.

*Issue #, if available:*

*Description of changes:*
Added ".py" at the end of navigation_test when calling the test node

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
