### PR TITLE
Corrected test.launch launchfile

### DIFF
--- a/simulation_ws/src/test_nodes/launch/test.launch
+++ b/simulation_ws/src/test_nodes/launch/test.launch
@@ -14,5 +14,5 @@
   <!-- Rotate the robot on launch -->
   <param name="SIM_TIMEOUT_SECONDS" type="int" value="$(optenv SIM_TIMEOUT_SECONDS 300)" />
   <param name="NAVIGATION_SUCCESS_COUNT" type="int" value="$(optenv NAVIGATION_SUCCESS_COUNT 1)" />
-  <node pkg="test_nodes" type="navigation_test" name="navigation_test" output="screen"/>
+  <node pkg="test_nodes" type="navigation_test.py" name="navigation_test" output="screen"/>
 </launch>


### PR DESCRIPTION
When calling this node, the launchfile would not recognize the type "navigation_test" in the node "test_nodes". This is because it is missing the ".py" at the end. Simple fix which worked for me.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
