### PR TITLE
Add colcon bundle retries - ROS2

### DIFF
--- a/.github/workflows/ros2.yml
+++ b/.github/workflows/ros2.yml
@@ -42,6 +42,7 @@ jobs:
         gazebo-version: ${{ matrix.gazebo }}
         workspace-dir: robot_ws
         generate-sources: true
+        colcon-bundle-retries: 3
     - id: simulation_ws_build
       name: Build and Bundle Simulation Workspace
       uses: aws-robotics/aws-robomaker-github-actions/robomaker-sample-app-ci@2.4.2
@@ -49,6 +50,7 @@ jobs:
         ros-distro: ${{ matrix.distro }}
         gazebo-version: ${{ matrix.gazebo }}
         workspace-dir: simulation_ws
+        colcon-bundle-retries: 3
 
   log_workflow_status_to_cloudwatch:
     runs-on: ubuntu-latest

--- a/.github/workflows/ros2.yml
+++ b/.github/workflows/ros2.yml
@@ -33,10 +33,10 @@ jobs:
         # TODO(setup-ros-docker#7): calling chown is necessary for now
         sudo chown -R rosbuild:rosbuild "$HOME" .
     - name: Scan using git-secrets
-      uses: aws-robotics/aws-robomaker-github-actions/git-secrets-scan-action@2.4.1
+      uses: aws-robotics/aws-robomaker-github-actions/git-secrets-scan-action@2.4.2
     - id: robot_ws_build
       name: Build and Bundle Robot Workspace
-      uses: aws-robotics/aws-robomaker-github-actions/robomaker-sample-app-ci@2.4.1
+      uses: aws-robotics/aws-robomaker-github-actions/robomaker-sample-app-ci@2.4.2
       with:
         ros-distro: ${{ matrix.distro }}
         gazebo-version: ${{ matrix.gazebo }}
@@ -44,7 +44,7 @@ jobs:
         generate-sources: true
     - id: simulation_ws_build
       name: Build and Bundle Simulation Workspace
-      uses: aws-robotics/aws-robomaker-github-actions/robomaker-sample-app-ci@2.4.1
+      uses: aws-robotics/aws-robomaker-github-actions/robomaker-sample-app-ci@2.4.2
       with:
         ros-distro: ${{ matrix.distro }}
         gazebo-version: ${{ matrix.gazebo }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add colcon bundle retries and bump robomaker gh action versions as a part of the change.

Blocked by - https://github.com/aws-robotics/aws-robomaker-github-actions/pull/22

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
