### PR TITLE
ignore flake8 b902 error in route_manager.py

### DIFF
--- a/simulation_ws/src/aws_robomaker_simulation_common/aws_robomaker_simulation_common/route_manager.py
+++ b/simulation_ws/src/aws_robomaker_simulation_common/aws_robomaker_simulation_common/route_manager.py
@@ -159,7 +159,7 @@ def main():
         rclpy.spin(route_manager)
     except KeyboardInterrupt:
         pass
-    except BaseException:
+    except BaseException: # NOQA: B902
         print('Exception in route_manager:', file=sys.stderr)
         raise
     finally:

--- a/simulation_ws/src/aws_robomaker_simulation_common/aws_robomaker_simulation_common/route_manager.py
+++ b/simulation_ws/src/aws_robomaker_simulation_common/aws_robomaker_simulation_common/route_manager.py
@@ -159,7 +159,7 @@ def main():
         rclpy.spin(route_manager)
     except KeyboardInterrupt:
         pass
-    except BaseException: # NOQA: B902
+    except BaseException:  # NOQA: B902
         print('Exception in route_manager:', file=sys.stderr)
         raise
     finally:


### PR DESCRIPTION
Flake8 validates against catching BaseExceptions in the code, but the purpose in this line of code is to catch all exception types.  Thus we do not have a good/simple workaround, so we will ignore this validation.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
