### PR TITLE
Bump version due to new canonical python patch

### DIFF
--- a/robot_ws/src/cloudwatch_robot/package.xml
+++ b/robot_ws/src/cloudwatch_robot/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>cloudwatch_robot</name>
-  <version>1.2.0</version>
+  <version>1.2.1</version>
   <description>
   AWS RoboMaker robot package that provides a sample application for integrating AWS CloudWatch with ROS.
   </description>

--- a/simulation_ws/src/aws_robomaker_simulation_common/package.xml
+++ b/simulation_ws/src/aws_robomaker_simulation_common/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>aws_robomaker_simulation_common</name>
-  <version>1.2.0</version>
+  <version>1.2.1</version>
   <description>
     AWS RoboMaker simulation package for commonly used nodes and helpers.
   </description>

--- a/simulation_ws/src/cloudwatch_simulation/package.xml
+++ b/simulation_ws/src/cloudwatch_simulation/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>cloudwatch_simulation</name>
-  <version>1.2.0</version>
+  <version>1.2.1</version>
   <description>
     AWS RoboMaker simulation package for launching a TurtleBot3 in a empty world or a small house.
   </description>

--- a/simulation_ws/src/test_nodes/package.xml
+++ b/simulation_ws/src/test_nodes/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>test_nodes</name>
-  <version>1.2.0</version>
+  <version>1.2.1</version>
   <description>
     AWS RoboMaker simulation test nodes.
   </description>


### PR DESCRIPTION
There was a security vulnerability in python. Bumping version in all packages given that the canonical python fix is patched.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
