### PR TITLE
Bump version due to new canonical python patch

### DIFF
--- a/robot_ws/src/cloudwatch_robot/package.xml
+++ b/robot_ws/src/cloudwatch_robot/package.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <package format="3">
   <name>cloudwatch_robot</name>
-  <version>2.1.0</version>
+  <version>2.1.1</version>
   <description>
   AWS RoboMaker robot package that provides a sample application for integrating AWS CloudWatch with ROS.
   </description>

--- a/simulation_ws/src/aws_robomaker_simulation_common/package.xml
+++ b/simulation_ws/src/aws_robomaker_simulation_common/package.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <package format="3">
   <name>aws_robomaker_simulation_common</name>
-  <version>2.1.0</version>
+  <version>2.1.1</version>
   <description>
     AWS RoboMaker simulation package for commonly used nodes and helpers.
   </description>

--- a/simulation_ws/src/aws_robomaker_simulation_common/setup.py
+++ b/simulation_ws/src/aws_robomaker_simulation_common/setup.py
@@ -6,7 +6,7 @@ package_name = 'aws_robomaker_simulation_common'
 
 setup(
     name=package_name,
-    version='2.0.0',
+    version='2.1.1',
     python_requires='>=3.5.0',
     packages=[package_name],
     data_files=[

--- a/simulation_ws/src/cloudwatch_simulation/package.xml
+++ b/simulation_ws/src/cloudwatch_simulation/package.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <package format="3">
   <name>cloudwatch_simulation</name>
-  <version>2.1.0</version>
+  <version>2.1.1</version>
   <description>
     AWS RoboMaker simulation package for launching a TurtleBot3 in a empty world or a small house.
   </description>

--- a/simulation_ws/src/cloudwatch_simulation/setup.py
+++ b/simulation_ws/src/cloudwatch_simulation/setup.py
@@ -7,7 +7,7 @@ package_name = 'cloudwatch_simulation'
 
 setup(
     name=package_name,
-    version='2.0.0',
+    version='2.1.1',
     packages=[package_name],
     data_files=[
         ('share/ament_index/resource_index/packages',


### PR DESCRIPTION
There was a security vulnerability in python. Bumping version in all packages given that the canonical python fix is patched.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
