### PR TITLE
Correct rviz model location

### DIFF
--- a/robot_ws/src/cloudwatch_robot/setup.py
+++ b/robot_ws/src/cloudwatch_robot/setup.py
@@ -51,7 +51,7 @@ setup(
         ('share/ament_index/resource_index/packages',
          ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml']),
-        ('rviz/', ['rviz/turtlebot3_navigation.rviz'])
+        ('share/rviz/', ['rviz/turtlebot3_navigation.rviz'])
     ],
     install_requires=['setuptools'],
     zip_safe=True,


### PR DESCRIPTION
*Description of changes:*

In the install folders, the `.rviz` file under the `cloudwatch_robot` package are under the `rviz` directory, when it should be under the `share/rviz` directory to be consistent with the `cloudwatch_simulation` package of the simulation workspace.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
